### PR TITLE
`single-item-highlight` no longer depends on other includes, & has more options

### DIFF
--- a/Galleries/single-item-highlight.html
+++ b/Galleries/single-item-highlight.html
@@ -1,8 +1,7 @@
 
-{% include ./single-item-highlight-custom-start.html
-    raised=include.raised
-%}
-<a href="{{ include.full }}" target="_blank" class="thumbnail-full-image-link"><img src="{{ include.thumb | default: include.full }}" {%- if include.alt %} alt="{{ include.alt }}" {%- endif %} class="thumbnail" /></a>
-{% include ./single-item-highlight-custom-end.html
-    caption=include.caption
-%}
+<figure class="thumbnail-gallery   card {%- if include.raised %} raised {%- endif %}   {%- if include.float != blank %}   {{ include.float }} {%- endif %}">
+<a href="{{ include.full }}" target="_blank" class="thumbnail-full-image-link"><img src="{{ include.thumb | default: include.full }}" {%- if include.alt %} alt="{{ include.alt }}" {%- endif %} class="thumbnail {%- if include.small %} small {%- endif %}" /></a>
+{%- if include.caption %}
+<figcaption class="caption">{{ include.caption }}</figcaption>
+{%- endif %}
+</figure>


### PR DESCRIPTION
- Now can float right or left with the `float` include argument
- Now can be optimized for smallness with the `small` include argument
